### PR TITLE
feat(build): add HAR normalize opt-out for v1.9.1

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@
   <p>
     <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/actions/workflows/ci.yml"><img alt="Checks" src="https://img.shields.io/badge/checks-passing-16a34a?style=flat-square&logo=githubactions&logoColor=white"></a>
     <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-0f766e?style=flat-square"></a>
-    <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases"><img alt="Version" src="https://img.shields.io/badge/version-v1.9.0-111827?style=flat-square"></a>
+    <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases"><img alt="Version" src="https://img.shields.io/badge/version-v1.9.1-111827?style=flat-square"></a>
     <a href="./docs/support-matrix.md"><img alt="Matrix" src="https://img.shields.io/badge/matrix-expo55--rnoh082--ui--stack-2563eb?style=flat-square"></a>
     <img alt="Input" src="https://img.shields.io/badge/input-Managed%2FCNG%20%2B%20bare%20intake-059669?style=flat-square">
   </p>
@@ -24,7 +24,7 @@
 </div>
 
 > [!IMPORTANT]
-> `v1.9.0` keeps the `verified + preview + experimental` model and brings bare workflow intake, five app foundation modules, and the `react-native-gesture-handler` formal slice onto the mainline tracker. The public promise remains tighter: `latest` only carries fully accepted `verified` capabilities, while `next` is reserved for preview fast-track work. The expanded goal still does not widen the current `verified` boundary yet.
+> `v1.9.1` keeps the `v1.9.0` bare workflow intake, app foundation modules, and `react-native-gesture-handler` formal slice, and adds a local HAR normalize opt-out for `build-hap`. The public promise remains tighter: `latest` only carries fully accepted `verified` capabilities, while `next` is reserved for preview fast-track work. The expanded goal still does not widen the current `verified` boundary yet.
 
 > [!TIP]
 > The two validated `@react-native-oh-tpl/*` adapters in the public matrix are currently consumed via exact Git URLs and commits. For repository development and the official UI-stack sample, prefer `pnpm install --ignore-scripts` so adapter prepare hooks do not fail on private upstream resources.
@@ -48,7 +48,7 @@
 <!-- GENERATED:readme-current-status:start -->
 | Item | Status |
 | --- | --- |
-| Current version | `v1.9.0` |
+| Current version | `v1.9.1` |
 | Support model | `verified + preview + experimental` |
 | Public `verified` matrix | `expo55-rnoh082-ui-stack` |
 | Supported input | Managed/CNG Expo projects; bare workflow intake baseline |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <p>
     <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/actions/workflows/ci.yml"><img alt="Checks" src="https://img.shields.io/badge/checks-passing-16a34a?style=flat-square&logo=githubactions&logoColor=white"></a>
     <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-0f766e?style=flat-square"></a>
-    <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases"><img alt="Version" src="https://img.shields.io/badge/version-v1.9.0-111827?style=flat-square"></a>
+    <a href="https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases"><img alt="Version" src="https://img.shields.io/badge/version-v1.9.1-111827?style=flat-square"></a>
     <a href="./docs/support-matrix.md"><img alt="Matrix" src="https://img.shields.io/badge/matrix-expo55--rnoh082--ui--stack-2563eb?style=flat-square"></a>
     <img alt="Input" src="https://img.shields.io/badge/input-Managed%2FCNG%20%2B%20bare%20intake-059669?style=flat-square">
   </p>
@@ -24,7 +24,7 @@
 </div>
 
 > [!IMPORTANT]
-> `v1.9.0` 延续 `verified + preview + experimental` 三层支持模型，并把 bare workflow intake、五个 app foundation modules 与 `react-native-gesture-handler` formal slice 纳入主线追踪。当前公开承诺仍然收紧为：`latest` 只承诺完整验收的 `verified` 能力，`next` 用于 preview fast track。目标扩大不等于当前 `verified` 边界已经放宽。
+> `v1.9.1` 延续 `v1.9.0` 的 bare workflow intake、app foundation modules 与 `react-native-gesture-handler` formal slice，并为 `build-hap` 增加本地 HAR normalize opt-out。当前公开承诺仍然收紧为：`latest` 只承诺完整验收的 `verified` 能力，`next` 用于 preview fast track。目标扩大不等于当前 `verified` 边界已经放宽。
 
 > [!TIP]
 > 由于当前公开矩阵内的两套 `@react-native-oh-tpl/*` adapter 依赖以 Git URL + exact commit 形式接入，仓库开发和官方 UI-stack sample 推荐使用 `pnpm install --ignore-scripts`，避免 Git adapter 在 prepare 阶段拉取私有资源而中断安装。
@@ -48,7 +48,7 @@
 <!-- GENERATED:readme-current-status:start -->
 | 项目 | 说明 |
 | --- | --- |
-| 当前版本 | `v1.9.0` |
+| 当前版本 | `v1.9.1` |
 | 支持模型 | `verified + preview + experimental` |
 | 唯一 `verified` 公开矩阵 | `expo55-rnoh082-ui-stack` |
 | 输入范围 | Managed/CNG Expo 项目；bare workflow intake baseline |

--- a/docs/cli-build.md
+++ b/docs/cli-build.md
@@ -1,6 +1,6 @@
 # CLI 构建指南
 
-`v1.9.0` 延续 `verified + preview + experimental` 支持分层，把 bare workflow 放进 intake baseline，并把五个 app foundation modules 纳入 preview shim baseline；`expo55-rnoh082-ui-stack` 仍是唯一 verified 矩阵。
+`v1.9.1` 延续 `verified + preview + experimental` 支持分层，把 bare workflow 放进 intake baseline，并补上 `build-hap` 的本地 HAR normalize opt-out；`expo55-rnoh082-ui-stack` 仍是唯一 verified 矩阵。
 
 CLI 命令集合不变：
 
@@ -104,6 +104,27 @@ toolkit 不会改动用户业务路由、动画逻辑或页面源码；它只负
 expo-harmony env --strict
 expo-harmony build-hap --mode debug
 ```
+
+### HAR normalize opt-out
+
+默认情况下，`build-hap` 会把 root / entry `oh-package.json5` 里的 `file:*.har` 本地依赖解压到 `harmony/expo-harmony-local-deps`，再让 `ohpm` 消费解压后的目录。这条路径仍是默认 verified build path。
+
+如果项目已经确认当前 DevEco / ohpm 能直接消费纯 HAR，可以显式跳过这一步：
+
+```bash
+EXPO_HARMONY_SKIP_HAR_NORMALIZE=1 expo-harmony build-hap --mode debug
+expo-harmony build-hap --mode debug --no-har-normalize
+```
+
+开启后：
+
+- `file:../node_modules/.../*.har` specifier 会保持原样
+- 不生成 `expo-harmony-local-deps`
+- 不临时注册 normalized local HAR modules 到 `build-profile.json5`
+- 不执行依赖 normalized local RNOH 目录的 codegen / path 兜底
+- `ohpm install --all` 与 `hvigor assembleHap` 继续执行
+
+该开关是 escape hatch，不代表 opt-out 路径和默认路径具备完全相同的兼容兜底。
 
 ### Release
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,7 +66,7 @@
 
 ## 当前主线
 
-`v1.8.x` 已完成 repo 内可收口项，当前主线切到 `v1.9.x`。`v1.9.0` 先落 bare workflow baseline、app foundation modules 与 `react-native-gesture-handler` formal slice；剩余需要真机或 release HAP 的证据继续保留在 v1.8.x capability board，不阻塞 v1.9.x 的 bare / foundation / third-party onboarding 工作。
+`v1.8.x` 已完成 repo 内可收口项，当前主线切到 `v1.9.x`。`v1.9.0` 先落 bare workflow baseline、app foundation modules 与 `react-native-gesture-handler` formal slice；`v1.9.1` 作为 build-hap patch release，补上 HAR normalize opt-out，让已确认 ohpm 可直接消费纯 HAR 的项目可以绕过 `expo-harmony-local-deps`。剩余需要真机或 release HAP 的证据继续保留在 v1.8.x capability board，不阻塞 v1.9.x 的 bare / foundation / third-party onboarding 工作。
 
 ### v1.8.0 Intake Hardening + Parallel Promotion
 
@@ -153,7 +153,28 @@
   - acceptance 记录
 - 本阶段不改变 `verified` 边界；foundation modules 以 `preview` + `runtimeMode=shim` 记录，`react-native-gesture-handler` 以 `experimental` + formal adapter slice 记录
 
-### v1.9.1 Third-party Native Wave A
+### v1.9.1 Build HAP HAR Normalize Opt-out
+
+目标日期：`2026-06-02`
+
+目标：把 issue #1 中的本地 HAR 解压 opt-out 做成正式 patch release，同时不改变默认 verified build path。
+
+- `build-hap` 新增显式 opt-out：
+  - `EXPO_HARMONY_SKIP_HAR_NORMALIZE=1`
+  - `expo-harmony build-hap --no-har-normalize`
+- 默认继续执行现有 `normalizeLocalHarDependencies` 路径：
+  - 解压 `file:*.har` 到 `expo-harmony-local-deps`
+  - 临时改写 root / entry `oh-package.json5`
+  - 注册 normalized local HAR modules
+  - 执行依赖 normalized local package 的 RNOH codegen / path 兜底
+- opt-out 开启后：
+  - 保留 `file:../node_modules/.../*.har`
+  - 让 `ohpm install --all` 直接消费纯 HAR
+  - 在 build report / CLI 文档里明确提示跳过的自动兜底
+- 本阶段只改变 build-hap escape hatch，不扩大 `verified` 能力边界
+- `v1.9.0` 已经存在于 npm `next`，本阶段发布为 `v1.9.1` 并进入 `latest`
+
+### v1.9.2 Third-party Native Wave A
 
 目标日期：`2026-09-30`
 
@@ -172,7 +193,7 @@
   - debug + release evidence
 - 任何进入 Wave A 的 blocker，都不允许继续停留在“矩阵外模糊探索”
 
-### v1.9.2 Third-party Native Wave B + Regression Farm
+### v1.9.3 Third-party Native Wave B + Regression Farm
 
 目标日期：`2026-10-31`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-harmony-toolkit",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "面向 Managed/CNG Expo 项目的 HarmonyOS 迁移、准入检查与 UI-stack 构建工具链",
   "main": "app.plugin.js",
   "types": "build/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ export async function run(argv = process.argv): Promise<void> {
     .description('Build a Harmony HAP from the validated sidecar and bundle outputs')
     .option('-p, --project-root <path>', 'path to the Expo project')
     .option('--mode <mode>', 'build mode: debug or release', 'debug')
+    .option('--no-har-normalize', 'let ohpm consume file:*.har dependencies without extracting local HARs')
     .action(runBuildHapCommand);
 
   program

--- a/src/commands/buildHap.ts
+++ b/src/commands/buildHap.ts
@@ -5,6 +5,7 @@ import { writeBuildReport } from '../core/metadata';
 export interface BuildHapCommandOptions {
   projectRoot?: string;
   mode?: 'debug' | 'release';
+  harNormalize?: boolean;
 }
 
 export async function runBuildHapCommand(options: BuildHapCommandOptions): Promise<void> {
@@ -19,6 +20,7 @@ export async function runBuildHapCommand(options: BuildHapCommandOptions): Promi
 
   const report = await buildHapProject(projectRoot, {
     mode,
+    skipHarNormalize: options.harNormalize === false,
   });
   await writeBuildReport(projectRoot, report);
 

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -39,6 +39,9 @@ import { normalizeProjectRnohCliAutolinkingTemplates } from './build/rnohCompati
 export type { CommandRunner, CommandRunnerResult } from './build/commands';
 export { renderBuildReport } from './build/reporting';
 
+export const SKIP_HAR_NORMALIZE_WARNING =
+  'Local HAR normalization is disabled; ohpm will consume file:*.har dependencies directly and normalized build-profile/RNOH compatibility steps will be skipped.';
+
 interface BundleProjectOptions {
   env?: NodeJS.ProcessEnv;
   runner?: CommandRunner;
@@ -49,6 +52,7 @@ interface BuildHapProjectOptions {
   mode: 'debug' | 'release';
   env?: NodeJS.ProcessEnv;
   runner?: CommandRunner;
+  skipHarNormalize?: boolean;
 }
 
 export async function bundleProject(
@@ -245,6 +249,8 @@ export async function buildHapProject(
 ): Promise<BuildReport> {
   const runtimeEnv = options.env ?? process.env;
   const runCommand = options.runner ?? defaultCommandRunner;
+  const skipHarNormalize =
+    options.skipHarNormalize === true || runtimeEnv.EXPO_HARMONY_SKIP_HAR_NORMALIZE === '1';
   const loadedProject = await loadProject(projectRoot);
   const envReport = await buildEnvReport(loadedProject.projectRoot, {
     env: runtimeEnv,
@@ -258,6 +264,9 @@ export async function buildHapProject(
     ),
     ...relevantEnvAdvisories.map((issue) => `${issue.code}: ${issue.message}`),
   ];
+  if (skipHarNormalize) {
+    warnings.push(SKIP_HAR_NORMALIZE_WARNING);
+  }
   const blockingIssues: BlockingIssue[] = [];
 
   if (!envReport.hvigorPath) {
@@ -356,45 +365,47 @@ export async function buildHapProject(
   let restoreNormalizedRnohCodegenAlignment = async () => {};
   let restoreNormalizedHarmonyPackageJsons = async () => {};
 
-  try {
-    const normalizedLocalHarDependencies = await normalizeLocalHarDependencies(harmonyProjectRoot);
-    normalizedLocalHarPackages = normalizedLocalHarDependencies.packages;
-    restoreNormalizedDependencies = normalizedLocalHarDependencies.restore;
-    restoreNormalizedLocalHarModules = await ensureHarmonyBuildProfileSupportsNormalizedLocalDeps(
-      harmonyProjectRoot,
-      normalizedLocalHarDependencies.packages,
-    );
-    restoreNormalizedRnohCliAutolinkingTemplates =
-      await normalizeProjectRnohCliAutolinkingTemplates(loadedProject.projectRoot);
-    restoreNormalizedHarmonyPackageJsons =
-      await normalizeKnownHarmonyPackageJsons(loadedProject.projectRoot);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return createBuildReport({
-      projectRoot: loadedProject.projectRoot,
-      command: 'build-hap',
-      mode: options.mode,
-      status: 'failed',
-      harmonyProjectRoot,
-      entryFile: bundleReport.entryFile,
-      bundleOutputPath: bundleReport.bundleOutputPath,
-      assetsDestPath: bundleReport.assetsDestPath,
-      artifactPaths: [],
-      blockingIssues: [
-        {
-          code: 'build.hap.failed',
-          message,
-        },
-      ],
-      warnings: [...warnings, ...bundleReport.warnings],
-      steps,
-    });
-  }
+  if (!skipHarNormalize) {
+    try {
+      const normalizedLocalHarDependencies = await normalizeLocalHarDependencies(harmonyProjectRoot);
+      normalizedLocalHarPackages = normalizedLocalHarDependencies.packages;
+      restoreNormalizedDependencies = normalizedLocalHarDependencies.restore;
+      restoreNormalizedLocalHarModules = await ensureHarmonyBuildProfileSupportsNormalizedLocalDeps(
+        harmonyProjectRoot,
+        normalizedLocalHarDependencies.packages,
+      );
+      restoreNormalizedRnohCliAutolinkingTemplates =
+        await normalizeProjectRnohCliAutolinkingTemplates(loadedProject.projectRoot);
+      restoreNormalizedHarmonyPackageJsons =
+        await normalizeKnownHarmonyPackageJsons(loadedProject.projectRoot);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return createBuildReport({
+        projectRoot: loadedProject.projectRoot,
+        command: 'build-hap',
+        mode: options.mode,
+        status: 'failed',
+        harmonyProjectRoot,
+        entryFile: bundleReport.entryFile,
+        bundleOutputPath: bundleReport.bundleOutputPath,
+        assetsDestPath: bundleReport.assetsDestPath,
+        artifactPaths: [],
+        blockingIssues: [
+          {
+            code: 'build.hap.failed',
+            message,
+          },
+        ],
+        warnings: [...warnings, ...bundleReport.warnings],
+        steps,
+      });
+    }
 
-  restoreNormalizedRnohCodegenAlignment = await alignRnohCodegenWithNormalizedLocalPackage(
-    harmonyProjectRoot,
-    normalizedLocalHarPackages,
-  );
+    restoreNormalizedRnohCodegenAlignment = await alignRnohCodegenWithNormalizedLocalPackage(
+      harmonyProjectRoot,
+      normalizedLocalHarPackages,
+    );
+  }
 
   const ohpmCommand = buildInvocation(envReport.ohpmPath as string, ['install', '--all']);
   try {
@@ -431,10 +442,12 @@ export async function buildHapProject(
       });
     }
 
-    if (!normalizedLocalHarPackages.some((localPackage) => localPackage.packageName === '@rnoh/react-native-openharmony')) {
-      await ensureRnohGeneratedTsShim(harmonyProjectRoot);
+    if (!skipHarNormalize) {
+      if (!normalizedLocalHarPackages.some((localPackage) => localPackage.packageName === '@rnoh/react-native-openharmony')) {
+        await ensureRnohGeneratedTsShim(harmonyProjectRoot);
+      }
+      await patchRnohGeneratedCodegenForNormalizedLocalPackage(harmonyProjectRoot);
     }
-    await patchRnohGeneratedCodegenForNormalizedLocalPackage(harmonyProjectRoot);
     await patchKnownHarmonyAdapterCodegenOutputs(harmonyProjectRoot);
 
     const hvigorCommand = buildInvocation(envReport.hvigorPath as string, [

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,6 +1,6 @@
 export const TOOLKIT_PACKAGE_NAME = 'expo-harmony-toolkit';
 export const CLI_NAME = 'expo-harmony';
-export const TOOLKIT_VERSION = '1.9.0';
+export const TOOLKIT_VERSION = '1.9.1';
 export const TEMPLATE_VERSION = 'rnoh-0.82.29';
 export const RNOH_VERSION = '0.82.29';
 export const RNOH_CLI_VERSION = '0.82.29';

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -4,7 +4,12 @@ import JSON5 from 'json5';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'node:util';
-import { buildHapProject, bundleProject, CommandRunner } from '../src/core/build';
+import {
+  buildHapProject,
+  bundleProject,
+  CommandRunner,
+  SKIP_HAR_NORMALIZE_WARNING,
+} from '../src/core/build';
 import { initProject, syncProjectTemplate } from '../src/core/template';
 
 const minimalSampleRoot = path.join(__dirname, '..', 'examples', 'official-minimal-sample');
@@ -805,6 +810,177 @@ describe('bundle and HAP build reports', () => {
     expect(normalizedEntrySpecifier.endsWith('.har')).toBe(false);
     expect(await fs.readFile(harmonyRootPackagePath, 'utf8')).toBe(originalRootPackage);
     expect(await fs.readFile(harmonyEntryPackagePath, 'utf8')).toBe(originalEntryPackage);
+  }, 120000);
+
+  it('lets ohpm consume local HAR dependencies directly when HAR normalization is disabled through env', async () => {
+    const projectRoot = await createTempFixture(appShellSampleRoot);
+    const devecoRoot = await createFakeDevEcoStudio(projectRoot);
+    await initProject(projectRoot, true);
+
+    const harmonyRootPackagePath = path.join(projectRoot, 'harmony', 'oh-package.json5');
+    const harmonyEntryPackagePath = path.join(projectRoot, 'harmony', 'entry', 'oh-package.json5');
+    const originalRootPackage = await fs.readFile(harmonyRootPackagePath, 'utf8');
+    const originalEntryPackage = await fs.readFile(harmonyEntryPackagePath, 'utf8');
+    let rootSpecifierDuringOhpm = '';
+    let entrySpecifierDuringOhpm = '';
+
+    const runner: CommandRunner = async (_file, args, options) => {
+      if (args.includes('bundle-harmony')) {
+        const bundleOutput = args[args.indexOf('--bundle-output') + 1];
+        const assetsDest = args[args.indexOf('--assets-dest') + 1];
+        await fs.outputFile(bundleOutput, '__d(function(){})\n');
+        await fs.ensureDir(assetsDest);
+        return {
+          exitCode: 0,
+          stdout: 'bundled',
+          stderr: '',
+        };
+      }
+
+      if (args[0] === 'install' && args[1] === '--all') {
+        const rootPackage = JSON5.parse(await fs.readFile(harmonyRootPackagePath, 'utf8')) as {
+          overrides: Record<string, string>;
+        };
+        const entryPackage = JSON5.parse(await fs.readFile(harmonyEntryPackagePath, 'utf8')) as {
+          dependencies: Record<string, string>;
+        };
+        rootSpecifierDuringOhpm = rootPackage.overrides['@rnoh/react-native-openharmony'];
+        entrySpecifierDuringOhpm = entryPackage.dependencies['@rnoh/react-native-openharmony'];
+
+        return {
+          exitCode: 0,
+          stdout: 'installed',
+          stderr: '',
+        };
+      }
+
+      if (args.includes('assembleHap')) {
+        const hapPath = path.join(
+          options.cwd,
+          'entry',
+          'build',
+          'default',
+          'outputs',
+          'default',
+          'entry-default-unsigned.hap',
+        );
+        await fs.outputFile(hapPath, 'hap');
+        return {
+          exitCode: 0,
+          stdout: 'built',
+          stderr: '',
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      };
+    };
+
+    const report = await buildHapProject(projectRoot, {
+      mode: 'debug',
+      runner,
+      env: {
+        ...process.env,
+        EXPO_HARMONY_DISABLE_DEFAULT_PATHS: '1',
+        EXPO_HARMONY_DEVECO_STUDIO_PATH: devecoRoot,
+        EXPO_HARMONY_JAVA_PATH: '/usr/bin/java',
+        EXPO_HARMONY_SKIP_HAR_NORMALIZE: '1',
+        PATH: '',
+      },
+    });
+
+    expect(report.status).toBe('succeeded');
+    expect(report.warnings).toContain(SKIP_HAR_NORMALIZE_WARNING);
+    expect(rootSpecifierDuringOhpm).toBe(
+      'file:../node_modules/@react-native-oh/react-native-harmony/react_native_openharmony.har',
+    );
+    expect(entrySpecifierDuringOhpm).toBe(
+      'file:../node_modules/@react-native-oh/react-native-harmony/react_native_openharmony.har',
+    );
+    expect(await fs.pathExists(path.join(projectRoot, 'harmony', 'expo-harmony-local-deps'))).toBe(false);
+    expect(await fs.readFile(harmonyRootPackagePath, 'utf8')).toBe(originalRootPackage);
+    expect(await fs.readFile(harmonyEntryPackagePath, 'utf8')).toBe(originalEntryPackage);
+  }, 120000);
+
+  it('lets callers disable HAR normalization through build options', async () => {
+    const projectRoot = await createTempFixture(appShellSampleRoot);
+    const devecoRoot = await createFakeDevEcoStudio(projectRoot);
+    await initProject(projectRoot, true);
+
+    let sawOriginalHarSpecifier = false;
+
+    const runner: CommandRunner = async (_file, args, options) => {
+      if (args.includes('bundle-harmony')) {
+        const bundleOutput = args[args.indexOf('--bundle-output') + 1];
+        const assetsDest = args[args.indexOf('--assets-dest') + 1];
+        await fs.outputFile(bundleOutput, '__d(function(){})\n');
+        await fs.ensureDir(assetsDest);
+        return {
+          exitCode: 0,
+          stdout: 'bundled',
+          stderr: '',
+        };
+      }
+
+      if (args[0] === 'install' && args[1] === '--all') {
+        const rootPackage = JSON5.parse(
+          await fs.readFile(path.join(projectRoot, 'harmony', 'oh-package.json5'), 'utf8'),
+        ) as {
+          overrides: Record<string, string>;
+        };
+        sawOriginalHarSpecifier = rootPackage.overrides['@rnoh/react-native-openharmony'].endsWith('.har');
+        return {
+          exitCode: 0,
+          stdout: 'installed',
+          stderr: '',
+        };
+      }
+
+      if (args.includes('assembleHap')) {
+        const hapPath = path.join(
+          options.cwd,
+          'entry',
+          'build',
+          'default',
+          'outputs',
+          'default',
+          'entry-default-unsigned.hap',
+        );
+        await fs.outputFile(hapPath, 'hap');
+        return {
+          exitCode: 0,
+          stdout: 'built',
+          stderr: '',
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      };
+    };
+
+    const report = await buildHapProject(projectRoot, {
+      mode: 'debug',
+      runner,
+      skipHarNormalize: true,
+      env: {
+        ...process.env,
+        EXPO_HARMONY_DISABLE_DEFAULT_PATHS: '1',
+        EXPO_HARMONY_DEVECO_STUDIO_PATH: devecoRoot,
+        EXPO_HARMONY_JAVA_PATH: '/usr/bin/java',
+        PATH: '',
+      },
+    });
+
+    expect(report.status).toBe('succeeded');
+    expect(sawOriginalHarSpecifier).toBe(true);
+    expect(report.warnings).toContain(SKIP_HAR_NORMALIZE_WARNING);
+    expect(await fs.pathExists(path.join(projectRoot, 'harmony', 'expo-harmony-local-deps'))).toBe(false);
   }, 120000);
 
   it('temporarily aligns codegen with the normalized local RNOH package when ohpm removes the shim', async () => {

--- a/tests/buildHapCommand.test.ts
+++ b/tests/buildHapCommand.test.ts
@@ -1,0 +1,65 @@
+import path from 'path';
+import { runBuildHapCommand } from '../src/commands/buildHap';
+import { buildHapProject } from '../src/core/build';
+import { writeBuildReport } from '../src/core/metadata';
+
+jest.mock('../src/core/build', () => ({
+  buildHapProject: jest.fn(),
+  renderBuildReport: jest.fn(() => 'rendered build report'),
+}));
+
+jest.mock('../src/core/metadata', () => ({
+  writeBuildReport: jest.fn(),
+}));
+
+const mockedBuildHapProject = buildHapProject as jest.MockedFunction<typeof buildHapProject>;
+const mockedWriteBuildReport = writeBuildReport as jest.MockedFunction<typeof writeBuildReport>;
+
+describe('build-hap command', () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.exitCode = originalExitCode;
+    mockedBuildHapProject.mockResolvedValue({
+      generatedAt: '2026-06-02T00:00:00.000Z',
+      projectRoot: path.resolve('.'),
+      toolkitVersion: '1.9.1',
+      command: 'build-hap',
+      mode: 'debug',
+      status: 'succeeded',
+      harmonyProjectRoot: path.resolve('harmony'),
+      entryFile: null,
+      bundleOutputPath: null,
+      assetsDestPath: null,
+      artifactPaths: [],
+      blockingIssues: [],
+      warnings: [],
+      steps: [],
+    });
+    mockedWriteBuildReport.mockResolvedValue(path.resolve('.expo-harmony', 'build-report.json'));
+  });
+
+  afterAll(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  it('passes the no-HAR-normalize flag to the build layer', async () => {
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      await runBuildHapCommand({
+        projectRoot: '.',
+        mode: 'debug',
+        harNormalize: false,
+      });
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+
+    expect(mockedBuildHapProject).toHaveBeenCalledWith(path.resolve('.'), {
+      mode: 'debug',
+      skipHarNormalize: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an explicit HAR normalize opt-out for `build-hap` via `EXPO_HARMONY_SKIP_HAR_NORMALIZE=1` or `--no-har-normalize`.
- Keeps the default verified build path unchanged, including local HAR extraction and normalized local dependency compatibility steps.
- Documents the opt-out tradeoff, updates the roadmap for the v1.9.1 patch release, and bumps the toolkit version to `1.9.1`.

Closes #1

## Validation

- `pnpm build`
- `pnpm exec jest --runInBand tests/build.test.ts tests/buildHapCommand.test.ts`
- `pnpm test`
- `npm pack --dry-run`
- `EXPO_HARMONY_RELEASE_SKIP_HAP=1 pnpm release:check`

## Release plan

- `expo-harmony-toolkit@1.9.0` already exists on npm and is currently tagged as `next`, so this change ships as `v1.9.1`.
- After merge, push tag `v1.9.1`; the release workflow should publish the package to npm with the `latest` dist-tag and provenance.
