### PR TITLE
📝 docs(release): record v1.11.4 publication evidence

### DIFF
--- a/acceptance/v1.11.4-acceptance.md
+++ b/acceptance/v1.11.4-acceptance.md
@@ -38,14 +38,16 @@
 
 ## 发布证据
 
-以下远端动作由 controller 在本地 release commit 后执行；本地对账不执行 npm、GitHub、tag 或 push 操作：
+以下远端发布证据已经完成对账：
 
-| Surface | 所需证据 |
+| Surface | 实际证据 |
 | --- | --- |
-| Git tag | `v1.11.4` 指向 release commit |
-| npm | `expo-harmony-toolkit@1.11.4` 发布到 `latest` |
-| GitHub Release | `v1.11.4` Release 已建立 |
-| GitHub Actions | tag 触发的 release workflow run 已记录 |
+| Git tag | `v1.11.4` 指向 `ab01e02dbbe28bdcf3af6062d869007409b40997`。 |
+| npm | `expo-harmony-toolkit@1.11.4` 已发布；`latest -> 1.11.4`；`next -> 1.9.0`。 |
+| GitHub Release | [v1.11.4](https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases/tag/v1.11.4)；`publishedAt=2026-08-15T19:25:49Z`；`draft=false`；`prerelease=false`。 |
+| Release workflow | [run 31903698914](https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/actions/runs/31903698914) `success`，`31903698914` success，`head=ab01e02dbbe28bdcf3af6062d869007409b40997`。 |
+| Main CI | `31903434400` success。 |
+| Pull request | PR `#3` 已 merge。 |
 
 ## 验收边界
 

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -240,10 +240,14 @@ describe('documentation metadata', () => {
     expect(v1114Acceptance).toContain('`EXPO_HARMONY_RELEASE_SKIP_HAP=1 pnpm release:check`');
     expect(v1114Acceptance).toContain('`exit 0`');
     expect(v1114Acceptance).toContain('发布证据');
-    expect(v1114Acceptance).toContain('| Git tag | `v1.11.4` 指向 release commit |');
-    expect(v1114Acceptance).toContain('| npm | `expo-harmony-toolkit@1.11.4` 发布到 `latest` |');
-    expect(v1114Acceptance).toContain('| GitHub Release | `v1.11.4` Release 已建立 |');
-    expect(v1114Acceptance).toContain('| GitHub Actions | tag 触发的 release workflow run 已记录 |');
+    expect(v1114Acceptance).toContain('`v1.11.4` 指向 `ab01e02dbbe28bdcf3af6062d869007409b40997`');
+    expect(v1114Acceptance).toContain('`latest -> 1.11.4`；`next -> 1.9.0`');
+    expect(v1114Acceptance).toContain('https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases/tag/v1.11.4');
+    expect(v1114Acceptance).toContain('`publishedAt=2026-08-15T19:25:49Z`；`draft=false`；`prerelease=false`');
+    expect(v1114Acceptance).toContain('`31903698914` success，`head=ab01e02dbbe28bdcf3af6062d869007409b40997`');
+    expect(v1114Acceptance).toContain('https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/actions/runs/31903698914');
+    expect(v1114Acceptance).toContain('`31903434400` success');
+    expect(v1114Acceptance).toContain('PR `#3` 已 merge');
     const cliBuild = await fs.readFile(path.join(repoRoot, 'docs', 'cli-build.md'), 'utf8');
     expect(cliBuild).toContain('`v1.11.4` 延续');
     expect(cliBuild).toContain('expo-harmony build-hap --mode release\n```');


### PR DESCRIPTION
## Summary

- replace the pending v1.11.4 publication checklist with actual release evidence
- record the tag commit, npm dist-tags, GitHub Release, release workflow, main CI, and merged PR
- lock the immutable acceptance evidence with focused documentation assertions

## Validation

- `pnpm exec jest --runInBand tests/docs.test.ts` (6/6)
- `pnpm build`
- full pre-push test suite (105/105)
- independent evidence review approved

## Risk and rollback

Documentation and documentation tests only. Revert this commit if any recorded remote evidence is later proven incorrect; the v1.11.4 tag itself is not modified.