### PR TITLE
Reconcile v2 prerelease publication state

### DIFF
--- a/acceptance/v2.0.0-non-device-closeout.md
+++ b/acceptance/v2.0.0-non-device-closeout.md
@@ -5,8 +5,9 @@
 - Tarball SHA-256: `b2d390b1e452803644fb687d4ece6676c66e9d3f46656d3ac52a1e053ebc12e1`
 - 日期：`2026-08-16 ～ 2026-08-23`
 - 範圍：`5 lane groups / 7 physical projects` 的 packed portable、debug HAP、release HAP、signed simulator basic runtime與19條route非實機證據
-- Publication status：`未发布`；本記錄不代表 npm、Git tag 或 GitHub Release 已建立
-- 執行型態：HAP、simulator與route證據來自本地驗收，沒有對應CI run id；repository push、PR或merge不等於npm、Git tag或GitHub Release已發布
+- Publication status：`已發布`；npm `next=2.0.0-next.0`、`latest=1.11.4`，Git tag 與 GitHub prerelease 均已核對
+- Publication evidence：tag commit `b5c1fe1443f746d2f6fbc3f07bff974cf8412821`；npm publish `2026-08-23T12:04:15.194Z`；[release workflow run 32637997199](https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/actions/runs/32637997199)；[GitHub prerelease](https://github.com/BlackishGreen33/Expo-Harmony-Toolkit/releases/tag/v2.0.0-next.0)
+- 執行型態：HAP、simulator 與 route 證據來自本地驗收，沒有對應 CI run id；正式 npm publish 另由上列 hosted CI run 完成
 
 ## 結論與邊界
 
@@ -160,6 +161,7 @@ EXPO_HARMONY_RELEASE_CHANNEL=next EXPO_HARMONY_RELEASE_SKIP_HAP=1 CI=1 pnpm rele
 - Final working tree 已通過 `pnpm install --frozen-lockfile`、`pnpm build`、18 suites / 143 tests 與 `pnpm pack:check` 135 entries。
 - Final npm repack 為 132226 bytes，SHA-256 是 `b2d390b1e452803644fb687d4ece6676c66e9d3f46656d3ac52a1e053ebc12e1`；三個修正後 debug HAP 都從這個 byte-equal tarball source-fresh materialize。
 - `EXPO_HARMONY_RELEASE_CHANNEL=next EXPO_HARMONY_RELEASE_SKIP_HAP=1 CI=1 pnpm release:check` 已 exit 0：packed consumer 共 482 dependencies、critical=0，七個 project 的 parsed doctor、init、第二次 sync `written=0`/`skipped=0` 與 marker-bearing bundle 全部通過。HAP 只因明確 skip flag 跳過，沒有以 portable 結果冒充 HAP 證據；三個受影響 lane 的 debug HAP 與 simulator action 另由上一節獨立證明。
-- `2.0.0-next.0` 在本記錄中維持未發布；repository push、PR或merge不改變此欄位，只有Git tag、npm publish與GitHub Release的實際遠端證據可改寫publication status。
-- 發布仍需通過whole-branch review與PR/CI；建立npm `next`、Git tag與GitHub prerelease後，另做post-release publication reconciliation。
+- `v2.0.0-next.0` tag 指向 merge commit `b5c1fe1443f746d2f6fbc3f07bff974cf8412821`；hosted release workflow `32637997199` 已成功完成 `npm publish --tag next --provenance --access public`。
+- npm registry 已核對 `next=2.0.0-next.0` 且 `latest=1.11.4`；本次 prerelease 沒有漂移穩定 dist-tag。GitHub Release 為非 draft prerelease，發布時間 `2026-08-23T12:05:18Z`。
+- 本段是 tag 後的 publication-state reconciliation，不屬於已發布 tarball；repository push、PR 或 merge 本身仍不能替代 tag、npm 與 GitHub Release 的實際遠端證據。
 - 穩定版 `2.0.0` 不在本輪範圍；真機與各capability硬體語義仍是獨立deferred gate。

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -359,11 +359,15 @@ describe('documentation metadata', () => {
     expect(closeout).toContain('GHSA-w3rx-r6r6-pgpr');
     expect(closeout).toContain('GHSA-5p2g-fcmc-qvqq');
     expect(closeout).toContain('GHSA-w5hq-g745-h8pq');
-    expect(closeout).toContain('未发布');
+    expect(closeout).not.toContain('未发布');
     expect(closeout).toContain('Publication status');
-    expect(closeout.match(/^- Publication status：`([^`]+)`/m)?.[1]).toBe('未发布');
-    expect(closeout).toContain('repository push、PR或merge不等於npm、Git tag或GitHub Release已發布');
-    expect(closeout).not.toMatch(/^- Publication status：`(?:已发布|published)`/im);
+    expect(closeout.match(/^- Publication status：`([^`]+)`/m)?.[1]).toBe('已發布');
+    expect(closeout).toContain('next=2.0.0-next.0');
+    expect(closeout).toContain('latest=1.11.4');
+    expect(closeout).toContain('b5c1fe1443f746d2f6fbc3f07bff974cf8412821');
+    expect(closeout).toContain('actions/runs/32637997199');
+    expect(closeout).toContain('releases/tag/v2.0.0-next.0');
+    expect(closeout).toContain('repository push、PR 或 merge 本身仍不能替代');
     expect(closeout).toContain('simulator pass 不是 device pass');
     expect(closeout).toContain('真机语义保持 deferred');
     expect(closeout).not.toMatch(


### PR DESCRIPTION
## What

- record the published v2.0.0-next.0 tag, npm dist-tags, release workflow, and GitHub prerelease
- keep post-tag reconciliation distinct from the immutable release tarball evidence

## Verification

- pnpm vitest run tests/docs.test.ts
- pre-push verification: 18 suites, 143 tests, and build passed