### PR TITLE
✨ feat(compat): add Expo 55-57 project matrices

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -52,10 +52,10 @@
 <!-- GENERATED:readme-current-status:start -->
 | Item | Status |
 | --- | --- |
-| Current version | `v2.0.0-next.0` |
+| Current version | `v2.0.0-next.1` |
 | Support model | `verified + preview + experimental` |
 | Public `verified` matrix | `expo55-rnoh082-ui-stack` |
-| Supported input | Managed/CNG Expo projects; bare and catalog-out intake classification |
+| Supported input | Expo SDK 55–57 Managed/CNG projects; bare and catalog-out intake classification |
 | `verified` JS/UI capabilities | `expo-router`, `expo-linking`, `expo-constants`, `react-native-reanimated`, `react-native-svg` |
 | `preview` native capabilities | `expo-file-system`, `expo-image-picker`, `expo-location`, `expo-camera`, `expo-secure-store`, `expo-asset`, `expo-device`, `expo-clipboard`, `expo-haptics` |
 | `experimental` capabilities | `expo-notifications`, `react-native-gesture-handler`, `@react-native-async-storage/async-storage`, `react-native-screens`, `react-native-safe-area-context`, `react-native-webview`, `jpush-react-native`, `expo-media-library`, `lottie-react-native`, `@shopify/react-native-skia` |
@@ -181,10 +181,11 @@ Common decision points:
 
 <!-- GENERATED:readme-support-matrix:start -->
 - `verified`: the only public matrix remains `expo55-rnoh082-ui-stack`
+- `preview project shapes`: `expo55-rn083-rnoh082-preview`, `expo56-rn085-rnoh082-preview`, `expo57-rn086-rnoh082-preview`
 - `preview`: `expo-file-system`, `expo-image-picker`, `expo-location`, `expo-camera`, `expo-secure-store`, `expo-asset`, `expo-device`, `expo-clipboard`, `expo-haptics`
 - `experimental`: `expo-notifications`, `react-native-gesture-handler`, `@react-native-async-storage/async-storage`, `react-native-screens`, `react-native-safe-area-context`, `react-native-webview`, `jpush-react-native`, `expo-media-library`, `lottie-react-native`, `@shopify/react-native-skia`
 
-`doctor --strict` still means `verified` only. `doctor --target-tier preview` allows the same runtime matrix plus preview-tier capabilities, but that does not promote them into the formal public promise.
+`doctor --strict` still means `verified` only. `doctor --target-tier preview` admits preview project shapes and capabilities without claiming RNOH runtime parity or a formal support promise.
 
 - `doctor-report.json` exposes `capabilities[].runtimeMode`
 - `doctor-report.json` and `toolkit-config.json` expose `evidence.bundle`, `evidence.debugBuild`, `evidence.device`, and `evidence.release`

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@
 <!-- GENERATED:readme-current-status:start -->
 | 项目 | 说明 |
 | --- | --- |
-| 当前版本 | `v2.0.0-next.0` |
+| 当前版本 | `v2.0.0-next.1` |
 | 支持模型 | `verified + preview + experimental` |
 | 唯一 `verified` 公开矩阵 | `expo55-rnoh082-ui-stack` |
-| 输入范围 | Managed/CNG Expo 项目；bare 与 catalog 外项目 intake 分类 |
+| 输入范围 | Expo SDK 55–57 Managed/CNG 项目；bare 与 catalog 外项目 intake 分类 |
 | `verified` JS/UI 能力 | `expo-router`、`expo-linking`、`expo-constants`、`react-native-reanimated`、`react-native-svg` |
 | `preview` 原生能力 | `expo-file-system`、`expo-image-picker`、`expo-location`、`expo-camera`、`expo-secure-store`、`expo-asset`、`expo-device`、`expo-clipboard`、`expo-haptics` |
 | `experimental` 能力 | `expo-notifications`、`react-native-gesture-handler`、`@react-native-async-storage/async-storage`、`react-native-screens`、`react-native-safe-area-context`、`react-native-webview`、`jpush-react-native`、`expo-media-library`、`lottie-react-native`、`@shopify/react-native-skia` |
@@ -181,10 +181,11 @@ pnpm exec expo-harmony build-hap --mode release
 
 <!-- GENERATED:readme-support-matrix:start -->
 - `verified`：唯一公开矩阵仍是 `expo55-rnoh082-ui-stack`
+- `preview project shapes`：`expo55-rn083-rnoh082-preview`, `expo56-rn085-rnoh082-preview`, `expo57-rn086-rnoh082-preview`
 - `preview`：`expo-file-system`, `expo-image-picker`, `expo-location`, `expo-camera`, `expo-secure-store`, `expo-asset`, `expo-device`, `expo-clipboard`, `expo-haptics`
 - `experimental`：`expo-notifications`, `react-native-gesture-handler`, `@react-native-async-storage/async-storage`, `react-native-screens`, `react-native-safe-area-context`, `react-native-webview`, `jpush-react-native`, `expo-media-library`, `lottie-react-native`, `@shopify/react-native-skia`
 
-`doctor --strict` 继续只代表 `verified`。`doctor --target-tier preview` 会在同一 runtime matrix 下额外放行 preview 能力，但这不等于它们已经进入正式承诺。
+`doctor --strict` 继续只代表 `verified`。`doctor --target-tier preview` 会放行 preview 项目形态与 preview 能力，但不代表 RNOH runtime parity 或正式承诺。
 
 - `doctor-report.json` 的 `capabilities[]` 会带出 `runtimeMode`
 - `doctor-report.json` 与 `toolkit-config.json` 会带出 `evidence.bundle`、`evidence.debugBuild`、`evidence.device`、`evidence.release`

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -38,6 +38,16 @@
 | App Shell 依赖 | `expo-router` `55.x`、`expo-linking` `55.x`、`expo-constants` `55.x`、`@expo/metro-runtime` `55.x`、`react-dom` `19.1.1` |
 | UI stack 依赖 | `react-native-reanimated` `3.6.0`、`react-native-svg` `15.0.0` |
 | 原生标识 | 至少设置 `android.package` 或 `ios.bundleIdentifier` |
+
+### Preview 项目形态矩阵
+
+以下矩阵只验证 Expo／React Native 项目形态可进入 RNOH 0.82 sidecar 的 bundle／build 路径，不代表 runtime parity、真机或 release 验收。
+
+| Matrix | Expo SDK | React | React Native | RNOH / CLI |
+| --- | --- | --- | --- | --- |
+| `expo55-rn083-rnoh082-preview` | `55` | `>=19.2.0 <20.0.0` | `>=0.83.0 <0.84.0` | `0.82.29` |
+| `expo56-rn085-rnoh082-preview` | `56` | `>=19.2.0 <20.0.0` | `>=0.85.0 <0.86.0` | `0.82.29` |
+| `expo57-rn086-rnoh082-preview` | `57` | `>=19.2.0 <20.0.0` | `>=0.86.0 <0.87.0` | `0.82.29` |
 <!-- GENERATED:support-matrix-verified-matrix:end -->
 
 ## Support Tiers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-harmony-toolkit",
-  "version": "2.0.0-next.0",
+  "version": "2.0.0-next.1",
   "description": "面向 Managed/CNG Expo 项目的 HarmonyOS 迁移、准入检查与 UI-stack 构建工具链",
   "main": "app.plugin.js",
   "types": "build/index.d.ts",
@@ -37,6 +37,7 @@
   "scripts": {
     "build": "rm -rf build && tsc --project tsconfig.json",
     "clean": "rm -rf build coverage",
+    "compat:check": "node ./scripts/version-compatibility-check.js",
     "docs:sync": "node ./scripts/update-generated-docs.js",
     "pack:check": "node ./scripts/pack.js --dry-run --json",
     "release:check": "node ./scripts/release-check.js",
@@ -77,10 +78,10 @@
     }
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": ">=55.0.0 <58.0.0"
   },
   "dependencies": {
-    "@expo/config": "^55.0.10",
+    "@expo/config": "^57.0.9",
     "commander": "^14.0.0",
     "fs-extra": "^11.3.0",
     "json5": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,13 +18,13 @@ importers:
   .:
     dependencies:
       '@expo/config':
-        specifier: ^55.0.10
-        version: 55.0.10(typescript@5.9.3)
+        specifier: ^57.0.9
+        version: 57.0.9(typescript@5.9.3)
       commander:
         specifier: ^14.0.0
         version: 14.0.3
       expo:
-        specifier: '*'
+        specifier: '>=55.0.0 <58.0.0'
         version: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       fs-extra:
         specifier: ^11.3.0
@@ -1225,17 +1225,23 @@ packages:
   '@expo/config-plugins@55.0.7':
     resolution: {integrity: sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==}
 
+  '@expo/config-plugins@57.0.9':
+    resolution: {integrity: sha512-hHgfL1avkCdEvDSw7IwlKwRYYNgcxzbNNMIk6W6lTkJpY0MajinAfeJUS0J+wPCsjUfGbVqOJM+XhPaO5ulUxg==}
+
   '@expo/config-types@55.0.5':
     resolution: {integrity: sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==}
 
   '@expo/config-types@55.0.6':
     resolution: {integrity: sha512-S+GJKYoIjnWlert/9vXuTohaTsMbyOLSVxdIgPgoq3P4N1p4CWrfyZLnz6qRug8wYSO5fcYcS9mFleyEP8wRLg==}
 
-  '@expo/config@55.0.10':
-    resolution: {integrity: sha512-qCHxo9H1ZoeW+y0QeMtVZ3JfGmumpGrgUFX60wLWMarraoQZSe47ZUm9kJSn3iyoPjUtUNanO3eXQg+K8k4rag==}
+  '@expo/config-types@57.0.2':
+    resolution: {integrity: sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==}
 
   '@expo/config@55.0.20':
     resolution: {integrity: sha512-TnJEOtdHCin2rZ/OVEGo0fuT+CWz0VqhyGWz+zsARvKP45aP8LFQMzeHuWmOpfm7XLJcsMen7Y5gO+xkzcRXkg==}
+
+  '@expo/config@57.0.9':
+    resolution: {integrity: sha512-dmzlKraIFxa7wLwV6K7WzI8jp6QZpW6Mc5mGjLimJUFjzh4uQdYaT3m3plEutM5yxBoBEwqzks7l+I/ljCbxAQ==}
 
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
@@ -1284,6 +1290,9 @@ packages:
 
   '@expo/json-file@10.2.0':
     resolution: {integrity: sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==}
+
+  '@expo/json-file@11.0.1':
+    resolution: {integrity: sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==}
 
   '@expo/local-build-cache-provider@55.0.7':
     resolution: {integrity: sha512-Qg9uNZn1buv4zJUA4ZQaz+ZnKDCipRgjoEg2Gcp8Qfy+2Gq5yZKX4YN1TThCJ01LJk/pvJsCRxXlXZSwdZppgg==}
@@ -1339,6 +1348,9 @@ packages:
   '@expo/plist@0.5.4':
     resolution: {integrity: sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg==}
 
+  '@expo/plist@0.8.1':
+    resolution: {integrity: sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==}
+
   '@expo/prebuild-config@55.0.10':
     resolution: {integrity: sha512-AMylDld5G7YJGfEhEyXtgWRuBB83802QBoewF1vJ6NMDtufukuPhMJzOs9E4UXNsjLTaQcgT4yTWhsAWl7o1AQ==}
     peerDependencies:
@@ -1364,6 +1376,14 @@ packages:
     resolution: {integrity: sha512-nkgOCNeWIVfLy3B+THeuqMGNKo0x6jBit9ofE09pHL7XHSkWcEnIYRCLgks8E3wj9q3ylcF1BQLrTxGhPja7iA==}
     peerDependencies:
       typescript: ^5.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@expo/require-utils@57.0.5':
+    resolution: {integrity: sha512-kTAXj9lDFEIPMsbAOGCGbjBbMF0oi7CqkYM79KOX0DDD9wSwXmlKL1z2h8OwsrBf7mbOo2DjlRvZu4BEjrIxGw==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6827,7 +6847,7 @@ snapshots:
   '@expo/cli@55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.1.1(react@19.1.1))(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(react@19.1.1)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devcert': 1.2.1
       '@expo/env': 2.1.1
@@ -6900,10 +6920,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@expo/cli@55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devcert': 1.2.1
       '@expo/env': 2.1.1
@@ -6917,7 +6937,7 @@ snapshots:
       '@expo/plist': 0.5.2
       '@expo/prebuild-config': 55.0.10(expo@55.0.8)(typescript@5.9.3)
       '@expo/require-utils': 55.0.3(typescript@5.9.3)
-      '@expo/router-server': 55.0.11(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.10)(expo-server@55.0.6)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@expo/router-server': 55.0.11(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo-server@55.0.6)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
       '@expo/schema-utils': 55.0.2
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
@@ -6961,7 +6981,7 @@ snapshots:
       ws: 8.20.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.10(dd9e5b45713ac29e92d7238f92e886f9)
+      expo-router: 55.0.10(b60efcf077e98696e51ab10866a5a1ca)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -7016,26 +7036,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-plugins@57.0.9(typescript@5.9.3)':
+    dependencies:
+      '@expo/config-types': 57.0.2
+      '@expo/json-file': 11.0.1
+      '@expo/plist': 0.8.1
+      '@expo/require-utils': 57.0.5(typescript@5.9.3)
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      semver: 7.7.4
+      slugify: 1.6.8
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@expo/config-types@55.0.5': {}
 
   '@expo/config-types@55.0.6': {}
 
-  '@expo/config@55.0.10(typescript@5.9.3)':
-    dependencies:
-      '@expo/config-plugins': 55.0.7
-      '@expo/config-types': 55.0.5
-      '@expo/json-file': 10.0.12
-      '@expo/require-utils': 55.0.3(typescript@5.9.3)
-      deepmerge: 4.3.1
-      getenv: 2.0.0
-      glob: 13.0.6
-      resolve-from: 5.0.0
-      resolve-workspace-root: 2.0.1
-      semver: 7.7.4
-      slugify: 1.6.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
+  '@expo/config-types@57.0.2': {}
 
   '@expo/config@55.0.20(typescript@5.9.3)':
     dependencies:
@@ -7043,6 +7067,22 @@ snapshots:
       '@expo/config-types': 55.0.6
       '@expo/json-file': 10.2.0
       '@expo/require-utils': 55.0.7(typescript@5.9.3)
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-workspace-root: 2.0.1
+      semver: 7.7.4
+      slugify: 1.6.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@expo/config@57.0.9(typescript@5.9.3)':
+    dependencies:
+      '@expo/config-plugins': 57.0.9(typescript@5.9.3)
+      '@expo/config-types': 57.0.2
+      '@expo/json-file': 11.0.1
+      '@expo/require-utils': 57.0.5(typescript@5.9.3)
       deepmerge: 4.3.1
       getenv: 2.0.0
       glob: 13.0.6
@@ -7156,9 +7196,14 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
+  '@expo/json-file@11.0.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      json5: 2.2.3
+
   '@expo/local-build-cache-provider@55.0.7(typescript@5.9.3)':
     dependencies:
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       chalk: 4.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7206,7 +7251,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/env': 2.1.1
       '@expo/json-file': 10.0.12
       '@expo/metro': 54.2.0
@@ -7307,9 +7352,15 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+  '@expo/plist@0.8.1':
+    dependencies:
+      '@xmldom/xmldom': 0.8.11
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
   '@expo/prebuild-config@55.0.10(expo@55.0.8)(typescript@5.9.3)':
     dependencies:
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/config-types': 55.0.5
       '@expo/image-utils': 0.8.12
@@ -7354,6 +7405,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/require-utils@57.0.5(typescript@5.9.3)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/router-server@55.0.11(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo-server@55.0.6)(expo@55.0.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       debug: 4.4.3
@@ -7369,7 +7430,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.11(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.10)(expo-server@55.0.6)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+  '@expo/router-server@55.0.11(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo-server@55.0.6)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
     dependencies:
       debug: 4.4.3
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -7379,7 +7440,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.9(@expo/dom-webview@55.0.5)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.10(dd9e5b45713ac29e92d7238f92e886f9)
+      expo-router: 55.0.10(b60efcf077e98696e51ab10866a5a1ca)
       react-dom: 19.2.4(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -9839,9 +9900,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@55.0.17(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0)):
+    dependencies:
+      '@expo/env': 2.1.3
+      expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   expo-constants@55.0.9(expo@55.0.8)(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(typescript@5.9.3):
     dependencies:
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/env': 2.1.1
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.1.1(react@19.1.1))(react-native-webview@13.13.5(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(react@19.1.1))(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(react@19.1.1)(typescript@5.9.3)
       react-native: 0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1)
@@ -9851,7 +9921,7 @@ snapshots:
 
   expo-constants@55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3):
     dependencies:
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/env': 2.1.1
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0)
@@ -10060,7 +10130,7 @@ snapshots:
       - expo-font
       - supports-color
 
-  expo-router@55.0.10(dd9e5b45713ac29e92d7238f92e886f9):
+  expo-router@55.0.10(b60efcf077e98696e51ab10866a5a1ca):
     dependencies:
       '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.9(@expo/dom-webview@55.0.5)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
@@ -10074,7 +10144,7 @@ snapshots:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3)
+      expo-constants: 55.0.17(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))
       expo-glass-effect: 55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
       expo-image: 55.0.8(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
       expo-linking: 55.0.11(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -10145,7 +10215,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       '@expo/cli': 55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.1.1(react@19.1.1))(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(react@19.1.1)(typescript@5.9.3)
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devtools': 55.0.2(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.1.1))(react@19.1.1)
       '@expo/fingerprint': 0.16.6
@@ -10186,8 +10256,8 @@ snapshots:
   expo@55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.13.5(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/cli': 55.0.18(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-constants@55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.10)(expo@55.0.8)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@expo/config': 55.0.20(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devtools': 55.0.2(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(react@19.2.0))(react@19.2.0)
       '@expo/fingerprint': 0.16.6

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -118,6 +118,7 @@ async function main() {
 
   await runCommand('pnpm', ['build']);
   await runCommand('pnpm', ['test']);
+  await runCommand('pnpm', ['compat:check']);
   await executeReleaseSmoke({
     version: packageJson.version,
     repoRoot,

--- a/scripts/version-compatibility-check.js
+++ b/scripts/version-compatibility-check.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const sampleRoot = path.join(repoRoot, 'examples', 'official-minimal-sample');
+const cliPath = path.join(repoRoot, 'bin', 'expo-harmony.js');
+const matrices = [
+  {
+    sdk: 55,
+    expo: '55.0.31',
+    react: '19.2.0',
+    reactNative: '0.83.10',
+    id: 'expo55-rn083-rnoh082-preview',
+  },
+  {
+    sdk: 56,
+    expo: '56.0.21',
+    react: '19.2.3',
+    reactNative: '0.85.3',
+    id: 'expo56-rn085-rnoh082-preview',
+  },
+  {
+    sdk: 57,
+    expo: '57.0.19',
+    react: '19.2.3',
+    reactNative: '0.86.3',
+    id: 'expo57-rn086-rnoh082-preview',
+  },
+];
+
+function run(file, args, cwd) {
+  const result = spawnSync(file, args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, CI: '1' },
+    maxBuffer: 50 * 1024 * 1024,
+    shell: false,
+  });
+
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      [
+        `${file} ${args.join(' ')} failed for ${cwd}.`,
+        result.error?.message,
+        result.stdout,
+        result.stderr,
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+    );
+  }
+
+  return result.stdout;
+}
+
+async function materializeProject(tempRoot, matrix) {
+  const projectRoot = path.join(tempRoot, `sdk-${matrix.sdk}`);
+  await fs.copy(sampleRoot, projectRoot, {
+    filter: (source) => path.basename(source) !== 'node_modules',
+  });
+  await Promise.all(
+    ['harmony', '.expo-harmony', 'index.harmony.js', 'metro.harmony.config.js'].map(
+      (relativePath) => fs.remove(path.join(projectRoot, relativePath)),
+    ),
+  );
+
+  const packageJson = await fs.readJson(path.join(projectRoot, 'package.json'));
+  packageJson.name = `expo-harmony-sdk-${matrix.sdk}-compat-smoke`;
+  packageJson.packageManager = 'pnpm@10.32.1';
+  packageJson.dependencies = {
+    '@babel/runtime': '^7.28.4',
+    '@expo/metro-runtime': `^${matrix.sdk}.0.0`,
+    '@react-native-oh/react-native-harmony': '0.82.29',
+    '@react-native-oh/react-native-harmony-cli': '0.82.29',
+    expo: matrix.expo,
+    'expo-constants': `^${matrix.sdk}.0.0`,
+    'expo-status-bar': '>=3.0.0 <4.0.0',
+    react: matrix.react,
+    'react-dom': matrix.react,
+    'react-native': matrix.reactNative,
+  };
+  packageJson.devDependencies = {
+    '@react-native-community/cli': '^20.1.2',
+    metro: '^0.83.1',
+  };
+  await fs.writeJson(path.join(projectRoot, 'package.json'), packageJson, { spaces: 2 });
+
+  return projectRoot;
+}
+
+async function main() {
+  const tempBase = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
+  const tempRoot = await fs.mkdtemp(path.join(tempBase, 'eht-compat-'));
+
+  try {
+    for (const matrix of matrices) {
+      const projectRoot = await materializeProject(tempRoot, matrix);
+      run(
+        'pnpm',
+        ['install', '--ignore-scripts', '--no-frozen-lockfile', '--strict-peer-dependencies=false'],
+        projectRoot,
+      );
+      const report = JSON.parse(
+        run(
+          process.execPath,
+          [cliPath, 'doctor', '--project-root', '.', '--target-tier', 'preview', '--json'],
+          projectRoot,
+        ).trim(),
+      );
+
+      if (
+        report.matrixId !== matrix.id ||
+        report.matrixSupportTier !== 'preview' ||
+        report.eligibility !== 'eligible'
+      ) {
+        throw new Error(`Expo SDK ${matrix.sdk} doctor report did not select ${matrix.id}.`);
+      }
+
+      run(process.execPath, [cliPath, 'init', '--project-root', '.', '--force'], projectRoot);
+      run(process.execPath, [cliPath, 'bundle', '--project-root', '.'], projectRoot);
+
+      const manifest = await fs.readJson(
+        path.join(projectRoot, '.expo-harmony', 'manifest.json'),
+      );
+      const bundlePath = path.join(
+        projectRoot,
+        'harmony',
+        'entry',
+        'src',
+        'main',
+        'resources',
+        'rawfile',
+        'bundle.harmony.js',
+      );
+      if (manifest.matrixId !== matrix.id || !(await fs.pathExists(bundlePath))) {
+        throw new Error(`Expo SDK ${matrix.sdk} did not produce ${matrix.id} bundle metadata.`);
+      }
+
+      if (process.env.EXPO_HARMONY_COMPAT_BUILD_HAP === '1') {
+        run(
+          process.execPath,
+          [cliPath, 'build-hap', '--project-root', '.', '--mode', 'debug'],
+          projectRoot,
+        );
+      }
+
+      const checks =
+        process.env.EXPO_HARMONY_COMPAT_BUILD_HAP === '1'
+          ? 'doctor/init/bundle/build-hap'
+          : 'doctor/init/bundle';
+      process.stdout.write(`Expo SDK ${matrix.sdk}: ${matrix.id} ${checks} passed.\n`);
+    }
+  } finally {
+    await fs.remove(tempRoot);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { main, matrices };

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,10 +1,10 @@
 export const TOOLKIT_PACKAGE_NAME = 'expo-harmony-toolkit';
 export const CLI_NAME = 'expo-harmony';
-export const TOOLKIT_VERSION = '2.0.0-next.0';
+export const TOOLKIT_VERSION = '2.0.0-next.1';
 export const TEMPLATE_VERSION = 'rnoh-0.82.29';
 export const RNOH_VERSION = '0.82.29';
 export const RNOH_CLI_VERSION = '0.82.29';
-export const SUPPORTED_EXPO_SDKS = [53, 55];
+export const SUPPORTED_EXPO_SDKS = [55, 56, 57];
 export const GENERATED_DIR = '.expo-harmony';
 export const GENERATED_SHIMS_DIR = `${GENERATED_DIR}/shims`;
 export const SIGNING_LOCAL_FILENAME = 'signing.local.json';

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -14,8 +14,7 @@ import { writeProjectJson } from './safeProjectWrite';
 import { annotateDependencyBuildability } from './dependencyInspection';
 import { DEPENDENCY_CATALOG } from '../data/dependencyCatalog';
 import {
-  DEFAULT_VALIDATED_MATRIX_ID,
-  VALIDATED_RELEASE_MATRICES,
+  resolveValidatedReleaseMatrix,
 } from '../data/validatedMatrices';
 import {
   CAPABILITY_BY_PACKAGE,
@@ -120,7 +119,7 @@ export async function buildDoctorReport(
     doctorConfig.excludeDependencies,
   );
   const expoSdkVersion = detectExpoSdkVersion(loadedProject.packageJson);
-  const matrix = VALIDATED_RELEASE_MATRICES[DEFAULT_VALIDATED_MATRIX_ID];
+  const matrix = resolveValidatedReleaseMatrix(loadedProject.packageJson, expoSdkVersion);
   const targetTier = options.targetTier ?? 'verified';
   const excludedPlugins = new Set(doctorConfig.excludePlugins);
   const expoPlugins = collectExpoPlugins(loadedProject.expoConfig).filter(
@@ -196,6 +195,7 @@ export async function buildDoctorReport(
     blocking: blockingDependencyNames.has(dependency.name),
   }));
   const nextActions = buildNextActions({
+    matrix,
     targetTier,
     coverageProfile,
     blockingIssues,
@@ -203,7 +203,12 @@ export async function buildDoctorReport(
     capabilities,
   });
 
-  const warnings = buildWarnings(loadedProject.expoConfig, expoSdkVersion, resolvedDependencies);
+  const warnings = buildWarnings(
+    loadedProject.expoConfig,
+    expoSdkVersion,
+    resolvedDependencies,
+    matrix,
+  );
   const advisories = buildAdvisories(loadedProject.expoConfig, doctorConfig);
 
   return {
@@ -213,6 +218,7 @@ export async function buildDoctorReport(
     toolkitVersion: TOOLKIT_VERSION,
     templateVersion: TEMPLATE_VERSION,
     matrixId: matrix.id,
+    matrixSupportTier: matrix.supportTier,
     eligibility: blockingIssues.length === 0 ? 'eligible' : 'ineligible',
     rnohVersion: RNOH_VERSION,
     rnohCliVersion: RNOH_CLI_VERSION,
@@ -273,7 +279,7 @@ export function renderDoctorReport(report: DoctorReport): string {
     `Project: ${report.projectRoot}`,
     `Config: ${report.appConfigPath ?? 'not found'}`,
     `Expo SDK: ${report.expoSdkVersion ?? 'unknown'} (recognized ${SUPPORTED_EXPO_SDKS.join(', ')})`,
-    `Matrix: ${report.matrixId ?? 'none'}`,
+    `Matrix: ${report.matrixId ?? 'none'} (${report.matrixSupportTier})`,
     `Target tier: ${report.targetTier}`,
     `Coverage profile: ${report.coverageProfile}`,
     `Eligibility: ${report.eligibility}`,
@@ -408,6 +414,13 @@ async function collectBlockingIssues(
 ): Promise<BlockingIssue[]> {
   const issues: BlockingIssue[] = [];
   const dependencyMap = new Map(dependencies.map((dependency) => [dependency.name, dependency]));
+
+  if (!isSupportTierAllowed(matrix.supportTier, targetTier)) {
+    issues.push({
+      code: 'matrix.support_tier.unsupported',
+      message: `Matrix ${matrix.id} is ${matrix.supportTier}; rerun doctor with --target-tier ${matrix.supportTier} to evaluate this project shape.`,
+    });
+  }
 
   if (expoSdkVersion !== matrix.expoSdkVersion) {
     issues.push({
@@ -691,6 +704,7 @@ function isThirdPartyNativeGapDependency(dependency: DetectedDependency): boolea
 }
 
 function buildNextActions(input: {
+  matrix: ValidatedReleaseMatrix;
   targetTier: DoctorTargetTier;
   coverageProfile: CoverageProfile;
   blockingIssues: BlockingIssue[];
@@ -698,7 +712,7 @@ function buildNextActions(input: {
   capabilities: ProjectCapabilityReport[];
 }): string[] {
   const actions: string[] = [];
-  const { targetTier, coverageProfile, blockingIssues, dependencies, capabilities } = input;
+  const { matrix, targetTier, coverageProfile, blockingIssues, dependencies, capabilities } = input;
   const hasPreviewCapabilities = capabilities.some((capability) => capability.supportTier === 'preview');
   const hasRouterBlockingIssues = blockingIssues.some((issue) =>
     [
@@ -715,14 +729,24 @@ function buildNextActions(input: {
     THIRD_PARTY_WAVE_B_PACKAGE_NAMES.has(dependency.name),
   );
 
+  if (hasBlockingIssueCode(blockingIssues, 'matrix.support_tier.unsupported')) {
+    actions.push(
+      `Use \`expo-harmony doctor --project-root . --target-tier ${matrix.supportTier}\` for ${matrix.id}; this project-shape lane does not expand the verified runtime promise.`,
+    );
+  }
+
   if (
     hasBlockingIssueCode(blockingIssues, 'matrix.expo_sdk.unsupported') ||
     hasBlockingIssueCode(blockingIssues, 'dependency.version_mismatch') ||
     hasBlockingIssueCode(blockingIssues, 'dependency.specifier_mismatch') ||
     hasBlockingIssueCode(blockingIssues, 'dependency.required_missing')
   ) {
+    const doctorMode =
+      matrix.supportTier === 'verified'
+        ? '--strict'
+        : `--target-tier ${matrix.supportTier}`;
     actions.push(
-      `Align Expo SDK, React Native, RNOH, and validated adapter versions to ${DEFAULT_VALIDATED_MATRIX_ID}, then rerun \`expo-harmony doctor --project-root . --strict\`.`,
+      `Align Expo SDK, React Native, RNOH, and validated adapter versions to ${matrix.id}, then rerun \`expo-harmony doctor --project-root . ${doctorMode}\`.`,
     );
   }
 
@@ -801,7 +825,9 @@ function buildNextActions(input: {
 
   if (coverageProfile === 'managed-core') {
     actions.push(
-      'Stay on the verified lane: rerun `expo-harmony sync-template --project-root .`, `expo-harmony bundle --project-root .`, and `expo-harmony build-hap --project-root . --mode debug` before claiming release readiness.',
+      matrix.supportTier === 'verified'
+        ? 'Stay on the verified lane: rerun `expo-harmony sync-template --project-root .`, `expo-harmony bundle --project-root .`, and `expo-harmony build-hap --project-root . --mode debug` before claiming release readiness.'
+        : `Stay on the ${matrix.supportTier} project-shape lane: rerun \`expo-harmony sync-template --project-root .\`, \`expo-harmony bundle --project-root .\`, and \`expo-harmony build-hap --project-root . --mode debug\`; successful packaging does not establish React Native runtime parity.`,
     );
   }
 
@@ -822,12 +848,19 @@ function buildWarnings(
   expoConfig: Record<string, any>,
   expoSdkVersion: number | null,
   dependencies: DetectedDependency[],
+  matrix: ValidatedReleaseMatrix,
 ): string[] {
   const warnings: string[] = [];
   const expoSdkWarning = getExpoSdkWarning(expoSdkVersion);
 
   if (expoSdkWarning) {
     warnings.push(expoSdkWarning);
+  }
+
+  if (matrix.supportTier !== 'verified') {
+    warnings.push(
+      `Matrix ${matrix.id} validates Expo/React Native project-shape intake against the RNOH ${RNOH_VERSION} sidecar as ${matrix.supportTier} only; bundle or debug-build success does not establish runtime parity or device acceptance.`,
+    );
   }
 
   if (!expoConfig.android?.package && !expoConfig.ios?.bundleIdentifier) {

--- a/src/core/template.ts
+++ b/src/core/template.ts
@@ -169,6 +169,7 @@ export async function syncProjectTemplate(
     doctorReport,
   );
   const previousManifest = await readManifest(loadedProject.projectRoot);
+  const matrixId = doctorReport.matrixId ?? DEFAULT_VALIDATED_MATRIX_ID;
   const forceManagedPaths = new Set(options.forceManagedPaths ?? []);
   const result: SyncResult = {
     writtenFiles: [],
@@ -178,7 +179,9 @@ export async function syncProjectTemplate(
     manifestPath: getManifestPath(loadedProject.projectRoot),
   };
 
-  result.warnings.push(...collectMetadataWarnings(previousManifest, previousToolkitConfig));
+  result.warnings.push(
+    ...collectMetadataWarnings(previousManifest, previousToolkitConfig, matrixId),
+  );
 
   const manifestFiles: ManagedFileRecord[] = [];
 
@@ -228,7 +231,7 @@ export async function syncProjectTemplate(
     generatedAt: new Date().toISOString(),
     toolkitVersion: TOOLKIT_VERSION,
     templateVersion: TEMPLATE_VERSION,
-    matrixId: DEFAULT_VALIDATED_MATRIX_ID,
+    matrixId,
     projectRoot: loadedProject.projectRoot,
     files: manifestFiles,
   };
@@ -315,7 +318,7 @@ async function buildManagedFiles(
     generatedAt: new Date().toISOString(),
     toolkitVersion: TOOLKIT_VERSION,
     templateVersion: TEMPLATE_VERSION,
-    matrixId: DEFAULT_VALIDATED_MATRIX_ID,
+    matrixId: doctorReport.matrixId ?? DEFAULT_VALIDATED_MATRIX_ID,
     rnohVersion: RNOH_VERSION,
     rnohCliVersion: RNOH_CLI_VERSION,
     bundleName: identifiers.bundleName,

--- a/src/core/template/support.ts
+++ b/src/core/template/support.ts
@@ -6,7 +6,6 @@ import {
   TEMPLATE_VERSION,
 } from '../constants';
 import { hasDeclaredDependency } from '../project';
-import { DEFAULT_VALIDATED_MATRIX_ID } from '../../data/validatedMatrices';
 import {
   HarmonyIdentifiers,
   PackageJson,
@@ -120,6 +119,7 @@ AppRegistry.registerComponent(${JSON.stringify(identifiers.slug)}, () => App);
 export function collectMetadataWarnings(
   previousManifest: ToolkitManifest | null,
   previousToolkitConfig: ToolkitConfig | null,
+  expectedMatrixId: string,
 ): string[] {
   const warnings: string[] = [];
 
@@ -129,9 +129,9 @@ export function collectMetadataWarnings(
     );
   }
 
-  if (previousManifest && previousManifest.matrixId !== DEFAULT_VALIDATED_MATRIX_ID) {
+  if (previousManifest && previousManifest.matrixId !== expectedMatrixId) {
     warnings.push(
-      `Existing manifest matrix ${previousManifest.matrixId ?? 'unknown'} does not match current matrix ${DEFAULT_VALIDATED_MATRIX_ID}. Sync will refresh managed metadata.`,
+      `Existing manifest matrix ${previousManifest.matrixId ?? 'unknown'} does not match current matrix ${expectedMatrixId}. Sync will refresh managed metadata.`,
     );
   }
 
@@ -141,9 +141,9 @@ export function collectMetadataWarnings(
     );
   }
 
-  if (previousToolkitConfig && previousToolkitConfig.matrixId !== DEFAULT_VALIDATED_MATRIX_ID) {
+  if (previousToolkitConfig && previousToolkitConfig.matrixId !== expectedMatrixId) {
     warnings.push(
-      `Existing toolkit-config matrix ${previousToolkitConfig.matrixId ?? 'unknown'} does not match current matrix ${DEFAULT_VALIDATED_MATRIX_ID}. Sync will refresh managed metadata.`,
+      `Existing toolkit-config matrix ${previousToolkitConfig.matrixId ?? 'unknown'} does not match current matrix ${expectedMatrixId}. Sync will refresh managed metadata.`,
     );
   }
 

--- a/src/data/validatedMatrices.ts
+++ b/src/data/validatedMatrices.ts
@@ -1,4 +1,5 @@
-import { ValidatedReleaseMatrix } from '../types';
+import semver from 'semver';
+import { PackageJson, ValidatedDependencyRule, ValidatedReleaseMatrix } from '../types';
 import { TOOLKIT_PACKAGE_NAME } from '../core/constants';
 import {
   UI_STACK_VALIDATED_ADAPTERS,
@@ -26,87 +27,180 @@ const BASE_ALLOWED_DEPENDENCIES = [
   TOOLKIT_PACKAGE_NAME,
 ] as const;
 
+const ALLOWED_DEPENDENCIES = [
+  ...BASE_ALLOWED_DEPENDENCIES,
+  ...UI_STACK_VALIDATED_ADAPTERS.flatMap((entry) => [
+    entry.canonicalPackageName,
+    entry.adapterPackageName,
+  ]),
+];
+
+function createDependencyRules(input: {
+  expoSdkVersion: number;
+  reactVersion: string;
+  reactNativeVersion: string;
+  reanimatedVersion: string;
+  svgVersion: string;
+}): Record<string, ValidatedDependencyRule> {
+  const expoRange = `>=${input.expoSdkVersion}.0.0 <${input.expoSdkVersion + 1}.0.0`;
+
+  return {
+    expo: {
+      required: true,
+      version: expoRange,
+    },
+    '@expo/metro-runtime': {
+      version: expoRange,
+    },
+    'expo-constants': {
+      version: expoRange,
+    },
+    'expo-linking': {
+      version: expoRange,
+    },
+    'expo-router': {
+      version: expoRange,
+    },
+    react: {
+      required: true,
+      version: input.reactVersion,
+    },
+    'react-dom': {
+      version: input.reactVersion,
+    },
+    'react-native': {
+      required: true,
+      version: input.reactNativeVersion,
+    },
+    '@react-native-oh/react-native-harmony': {
+      required: true,
+      version: '0.82.29',
+    },
+    '@react-native-oh/react-native-harmony-cli': {
+      required: true,
+      version: '0.82.29',
+    },
+    '@react-native-community/cli': {
+      required: true,
+      version: '>=20.0.0 <21.0.0',
+    },
+    metro: {
+      required: true,
+      version: '>=0.83.0 <0.84.0',
+    },
+    '@babel/runtime': {
+      version: '>=7.0.0 <8.0.0',
+    },
+    'expo-status-bar': {
+      version: '>=3.0.0 <4.0.0',
+    },
+    ...Object.fromEntries(
+      UI_STACK_VALIDATED_ADAPTERS.flatMap((entry) => [
+        [
+          entry.canonicalPackageName,
+          {
+            version:
+              entry.canonicalPackageName === 'react-native-reanimated'
+                ? input.reanimatedVersion
+                : input.svgVersion,
+          },
+        ],
+        [
+          entry.adapterPackageName,
+          {
+            specifiers: [
+              getUiStackAdapterSpecifier(entry),
+              getUiStackAdapterRepositorySpecifier(entry),
+            ],
+          },
+        ],
+      ]),
+    ),
+  };
+}
+
 export const VALIDATED_RELEASE_MATRICES: Record<string, ValidatedReleaseMatrix> = {
   [DEFAULT_VALIDATED_MATRIX_ID]: {
     id: DEFAULT_VALIDATED_MATRIX_ID,
+    supportTier: 'verified',
     expoSdkVersion: 55,
     nativeIdentifierRequirement: 'android_or_ios',
-    allowedDependencies: [
-      ...BASE_ALLOWED_DEPENDENCIES,
-      ...UI_STACK_VALIDATED_ADAPTERS.flatMap((entry) => [
-        entry.canonicalPackageName,
-        entry.adapterPackageName,
-      ]),
-    ],
-    dependencyRules: {
-      expo: {
-        required: true,
-        version: '>=55.0.0 <56.0.0',
-      },
-      '@expo/metro-runtime': {
-        version: '>=55.0.0 <56.0.0',
-      },
-      'expo-constants': {
-        version: '>=55.0.0 <56.0.0',
-      },
-      'expo-linking': {
-        version: '>=55.0.0 <56.0.0',
-      },
-      'expo-router': {
-        version: '>=55.0.0 <56.0.0',
-      },
-      react: {
-        required: true,
-        version: '19.1.1',
-      },
-      'react-dom': {
-        version: '19.1.1',
-      },
-      'react-native': {
-        required: true,
-        version: '0.82.1',
-      },
-      '@react-native-oh/react-native-harmony': {
-        required: true,
-        version: '0.82.29',
-      },
-      '@react-native-oh/react-native-harmony-cli': {
-        required: true,
-        version: '0.82.29',
-      },
-      '@react-native-community/cli': {
-        required: true,
-        version: '>=20.0.0 <21.0.0',
-      },
-      metro: {
-        required: true,
-        version: '>=0.83.0 <0.84.0',
-      },
-      '@babel/runtime': {
-        version: '>=7.0.0 <8.0.0',
-      },
-      'expo-status-bar': {
-        version: '>=3.0.0 <4.0.0',
-      },
-      ...Object.fromEntries(
-        UI_STACK_VALIDATED_ADAPTERS.flatMap((entry) => [
-          [
-            entry.canonicalPackageName,
-            {
-              version: entry.canonicalVersion,
-            },
-          ],
-          [
-            entry.adapterPackageName,
-            {
-              specifiers: [
-                getUiStackAdapterSpecifier(entry),
-                getUiStackAdapterRepositorySpecifier(entry),
-              ],
-            },
-          ],
-        ]),
-      ),
-    },
+    allowedDependencies: ALLOWED_DEPENDENCIES,
+    dependencyRules: createDependencyRules({
+      expoSdkVersion: 55,
+      reactVersion: '19.1.1',
+      reactNativeVersion: '0.82.1',
+      reanimatedVersion: '3.6.0',
+      svgVersion: '15.0.0',
+    }),
+  },
+  'expo55-rn083-rnoh082-preview': {
+    id: 'expo55-rn083-rnoh082-preview',
+    supportTier: 'preview',
+    expoSdkVersion: 55,
+    nativeIdentifierRequirement: 'android_or_ios',
+    allowedDependencies: ALLOWED_DEPENDENCIES,
+    dependencyRules: createDependencyRules({
+      expoSdkVersion: 55,
+      reactVersion: '>=19.2.0 <20.0.0',
+      reactNativeVersion: '>=0.83.0 <0.84.0',
+      reanimatedVersion: '>=4.0.0 <5.0.0',
+      svgVersion: '>=15.0.0 <16.0.0',
+    }),
+  },
+  'expo56-rn085-rnoh082-preview': {
+    id: 'expo56-rn085-rnoh082-preview',
+    supportTier: 'preview',
+    expoSdkVersion: 56,
+    nativeIdentifierRequirement: 'android_or_ios',
+    allowedDependencies: ALLOWED_DEPENDENCIES,
+    dependencyRules: createDependencyRules({
+      expoSdkVersion: 56,
+      reactVersion: '>=19.2.0 <20.0.0',
+      reactNativeVersion: '>=0.85.0 <0.86.0',
+      reanimatedVersion: '>=4.0.0 <5.0.0',
+      svgVersion: '>=15.0.0 <16.0.0',
+    }),
+  },
+  'expo57-rn086-rnoh082-preview': {
+    id: 'expo57-rn086-rnoh082-preview',
+    supportTier: 'preview',
+    expoSdkVersion: 57,
+    nativeIdentifierRequirement: 'android_or_ios',
+    allowedDependencies: ALLOWED_DEPENDENCIES,
+    dependencyRules: createDependencyRules({
+      expoSdkVersion: 57,
+      reactVersion: '>=19.2.0 <20.0.0',
+      reactNativeVersion: '>=0.86.0 <0.87.0',
+      reanimatedVersion: '>=4.0.0 <5.0.0',
+      svgVersion: '>=15.0.0 <16.0.0',
+    }),
   },
 };
+
+export function resolveValidatedReleaseMatrix(
+  packageJson: PackageJson,
+  expoSdkVersion: number | null,
+): ValidatedReleaseMatrix {
+  const candidates = Object.values(VALIDATED_RELEASE_MATRICES).filter(
+    (matrix) => matrix.expoSdkVersion === expoSdkVersion,
+  );
+  const reactNativeSpecifier =
+    packageJson.dependencies?.['react-native'] ??
+    packageJson.devDependencies?.['react-native'] ??
+    packageJson.peerDependencies?.['react-native'];
+  const reactNativeVersion = reactNativeSpecifier ? semver.coerce(reactNativeSpecifier) : null;
+
+  return (
+    candidates.find((matrix) => {
+      const range = matrix.dependencyRules['react-native']?.version;
+      return Boolean(
+        range &&
+          reactNativeVersion &&
+          semver.satisfies(reactNativeVersion, range, { includePrerelease: true }),
+      );
+    }) ??
+    candidates[0] ??
+    VALIDATED_RELEASE_MATRICES[DEFAULT_VALIDATED_MATRIX_ID]
+  );
+}

--- a/src/docs/render.ts
+++ b/src/docs/render.ts
@@ -15,6 +15,9 @@ import { UI_STACK_VALIDATED_ADAPTERS, getUiStackAdapterSpecifier } from '../data
 export type DocsLocale = 'zh' | 'en';
 
 const matrix = VALIDATED_RELEASE_MATRICES[DEFAULT_VALIDATED_MATRIX_ID];
+const previewMatrices = Object.values(VALIDATED_RELEASE_MATRICES).filter(
+  (candidate) => candidate.supportTier === 'preview',
+);
 
 export function renderReadmeCurrentStatus(locale: DocsLocale): string {
   const headers =
@@ -40,8 +43,8 @@ export function renderReadmeCurrentStatus(locale: DocsLocale): string {
       : `\`latest\` = ${PUBLIC_RELEASE_TRACKS.latest}; \`next\` = ${PUBLIC_RELEASE_TRACKS.next}`;
   const inputValue =
     locale === 'zh'
-      ? 'Managed/CNG Expo 项目；bare 与 catalog 外项目 intake 分类'
-      : 'Managed/CNG Expo projects; bare and catalog-out intake classification';
+      ? 'Expo SDK 55–57 Managed/CNG 项目；bare 与 catalog 外项目 intake 分类'
+      : 'Expo SDK 55–57 Managed/CNG projects; bare and catalog-out intake classification';
   const listJoiner = locale === 'zh' ? '、' : ', ';
 
   return [
@@ -72,6 +75,10 @@ export function renderReadmeSupportMatrixSection(locale: DocsLocale): string {
     locale === 'zh'
       ? `- \`preview\`：${joinInlineCode(PREVIEW_CAPABILITY_DEFINITIONS.map((definition) => definition.packageName))}`
       : `- \`preview\`: ${joinInlineCode(PREVIEW_CAPABILITY_DEFINITIONS.map((definition) => definition.packageName))}`;
+  const previewMatrixLine =
+    locale === 'zh'
+      ? `- \`preview project shapes\`：${joinInlineCode(previewMatrices.map((candidate) => candidate.id))}`
+      : `- \`preview project shapes\`: ${joinInlineCode(previewMatrices.map((candidate) => candidate.id))}`;
   const experimentalLine =
     locale === 'zh'
       ? `- \`experimental\`：${joinInlineCode(EXPERIMENTAL_CAPABILITY_NAMES)}`
@@ -79,8 +86,8 @@ export function renderReadmeSupportMatrixSection(locale: DocsLocale): string {
 
   const strictLine =
     locale === 'zh'
-      ? '`doctor --strict` 继续只代表 `verified`。`doctor --target-tier preview` 会在同一 runtime matrix 下额外放行 preview 能力，但这不等于它们已经进入正式承诺。'
-      : '`doctor --strict` still means `verified` only. `doctor --target-tier preview` allows the same runtime matrix plus preview-tier capabilities, but that does not promote them into the formal public promise.';
+      ? '`doctor --strict` 继续只代表 `verified`。`doctor --target-tier preview` 会放行 preview 项目形态与 preview 能力，但不代表 RNOH runtime parity 或正式承诺。'
+      : '`doctor --strict` still means `verified` only. `doctor --target-tier preview` admits preview project shapes and capabilities without claiming RNOH runtime parity or a formal support promise.';
 
   const telemetryLines =
     locale === 'zh'
@@ -101,7 +108,7 @@ export function renderReadmeSupportMatrixSection(locale: DocsLocale): string {
           '- `evidenceSource.device=manual-doc` means the current device signal comes from manual acceptance records, not automated verification',
         ];
 
-  return [verifiedLine, previewLine, experimentalLine, '', strictLine, '', ...telemetryLines].join('\n');
+  return [verifiedLine, previewMatrixLine, previewLine, experimentalLine, '', strictLine, '', ...telemetryLines].join('\n');
 }
 
 export function renderSupportMatrixVerifiedMatrix(locale: DocsLocale): string {
@@ -113,6 +120,13 @@ export function renderSupportMatrixVerifiedMatrix(locale: DocsLocale): string {
     locale === 'zh'
       ? '`react-native-reanimated` `3.6.0`、`react-native-svg` `15.0.0`'
       : '`react-native-reanimated` `3.6.0`, `react-native-svg` `15.0.0`';
+
+  const previewHeading =
+    locale === 'zh' ? '### Preview 项目形态矩阵' : '### Preview project-shape matrices';
+  const previewBoundary =
+    locale === 'zh'
+      ? '以下矩阵只验证 Expo／React Native 项目形态可进入 RNOH 0.82 sidecar 的 bundle／build 路径，不代表 runtime parity、真机或 release 验收。'
+      : 'These matrices validate Expo/React Native project-shape intake into the RNOH 0.82 sidecar bundle/build path only; they do not establish runtime parity, device acceptance, or release acceptance.';
 
   return [
     '| 项目 | 要求 |',
@@ -127,6 +141,16 @@ export function renderSupportMatrixVerifiedMatrix(locale: DocsLocale): string {
     `| App Shell 依赖 | ${appShellValue} |`,
     `| UI stack 依赖 | ${uiStackValue} |`,
     '| 原生标识 | 至少设置 `android.package` 或 `ios.bundleIdentifier` |',
+    '',
+    previewHeading,
+    '',
+    previewBoundary,
+    '',
+    '| Matrix | Expo SDK | React | React Native | RNOH / CLI |',
+    '| --- | --- | --- | --- | --- |',
+    ...previewMatrices.map((candidate) =>
+      `| \`${candidate.id}\` | \`${candidate.expoSdkVersion}\` | \`${candidate.dependencyRules.react?.version}\` | \`${candidate.dependencyRules['react-native']?.version}\` | \`${candidate.dependencyRules['@react-native-oh/react-native-harmony']?.version}\` |`,
+    ),
   ].join('\n');
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface ValidatedDependencyRule {
 
 export interface ValidatedReleaseMatrix {
   id: string;
+  supportTier: DoctorTargetTier;
   expoSdkVersion: number;
   allowedDependencies: string[];
   dependencyRules: Record<string, ValidatedDependencyRule>;
@@ -188,6 +189,7 @@ export interface DoctorReport {
   toolkitVersion: string;
   templateVersion: string;
   matrixId: string | null;
+  matrixSupportTier: DoctorTargetTier;
   eligibility: EligibilityStatus;
   rnohVersion: string;
   rnohCliVersion: string;

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -193,7 +193,7 @@ describe('documentation metadata', () => {
   it('keeps package metadata aligned with the public repository and license', async () => {
     const packageJson = await fs.readJson(packageJsonPath);
 
-    expect(TOOLKIT_VERSION).toBe('2.0.0-next.0');
+    expect(TOOLKIT_VERSION).toBe('2.0.0-next.1');
     expect(packageJson.version).toBe(TOOLKIT_VERSION);
     expect(packageJson.license).toBe('MIT');
     expect(packageJson.repository?.url).toBe('git+https://github.com/BlackishGreen33/Expo-Harmony-Toolkit.git');

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -210,6 +210,89 @@ describe('doctor report', () => {
     expect(report.dependencies.every((dependency) => dependency.blocking === false)).toBe(true);
   });
 
+  it.each([
+    {
+      expoSdkVersion: 55,
+      expoVersion: '^55.0.31',
+      reactVersion: '19.2.0',
+      reactNativeVersion: '0.83.10',
+      matrixId: 'expo55-rn083-rnoh082-preview',
+    },
+    {
+      expoSdkVersion: 56,
+      expoVersion: '^56.0.21',
+      reactVersion: '19.2.3',
+      reactNativeVersion: '0.85.3',
+      matrixId: 'expo56-rn085-rnoh082-preview',
+    },
+    {
+      expoSdkVersion: 57,
+      expoVersion: '^57.0.19',
+      reactVersion: '19.2.3',
+      reactNativeVersion: '0.86.3',
+      matrixId: 'expo57-rn086-rnoh082-preview',
+    },
+  ])(
+    'accepts the Expo $expoSdkVersion project shape on the preview lane',
+    async ({ expoSdkVersion, expoVersion, reactVersion, reactNativeVersion, matrixId }) => {
+      const tempRoot = await createDoctorFixtureFromSample();
+
+      try {
+        const packageJsonPath = path.join(tempRoot, 'package.json');
+        const packageJson = await fs.readJson(packageJsonPath);
+        packageJson.dependencies = {
+          ...packageJson.dependencies,
+          expo: expoVersion,
+          '@expo/metro-runtime': `^${expoSdkVersion}.0.0`,
+          'expo-constants': `^${expoSdkVersion}.0.0`,
+          react: reactVersion,
+          'react-dom': reactVersion,
+          'react-native': reactNativeVersion,
+        };
+        await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
+
+        const report = await buildDoctorReport(tempRoot, { targetTier: 'preview' });
+
+        expect(report.matrixId).toBe(matrixId);
+        expect(report.matrixSupportTier).toBe('preview');
+        expect(report.expoSdkVersion).toBe(expoSdkVersion);
+        expect(report.eligibility).toBe('eligible');
+        expect(report.blockingIssues).toHaveLength(0);
+      } finally {
+        await fs.remove(tempRoot);
+      }
+    },
+  );
+
+  it('keeps the Expo 56 compatibility matrix outside strict verified eligibility', async () => {
+    const tempRoot = await createDoctorFixtureFromSample();
+
+    try {
+      const packageJsonPath = path.join(tempRoot, 'package.json');
+      const packageJson = await fs.readJson(packageJsonPath);
+      packageJson.dependencies = {
+        ...packageJson.dependencies,
+        expo: '^56.0.21',
+        '@expo/metro-runtime': '^56.0.0',
+        'expo-constants': '^56.0.0',
+        react: '19.2.3',
+        'react-dom': '19.2.3',
+        'react-native': '0.85.3',
+      };
+      await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
+
+      const report = await buildDoctorReport(tempRoot);
+
+      expect(report.matrixId).toBe('expo56-rn085-rnoh082-preview');
+      expect(report.eligibility).toBe('ineligible');
+      expect(report.blockingIssues).toContainEqual(
+        expect.objectContaining({ code: 'matrix.support_tier.unsupported' }),
+      );
+    } finally {
+      await fs.remove(tempRoot);
+    }
+  });
+
   it('classifies the dedicated verified fixture as managed-core with matrix-drift dependency buckets', async () => {
     const report = await buildDoctorReport(verifiedFixtureRoot);
     const expoDependency = report.dependencies.find((dependency) => dependency.name === 'expo');


### PR DESCRIPTION
## 摘要

- 新增 Expo 55 / RN 0.83、Expo 56 / RN 0.85、Expo 57 / RN 0.86 的 preview project-shape 矩陣。
- 保留既有 Expo 55 / RN 0.82.1 verified 矩陣；新版矩陣必須使用 preview target，不提升正式 runtime 承諾。
- 將三版本真實相依 doctor、init、bundle smoke 納入 release gate，並更新 npm peer 與產生文件。

## 驗證

- `pnpm release:check`
- `EXPO_HARMONY_COMPAT_BUILD_HAP=1 pnpm compat:check`
- 18 suites / 147 tests
- ccnubox Expo 56 / RN 0.85 整合路徑產出 unsigned debug HAP

## 證據邊界

RNOH 與 CLI 仍固定為 0.82.29。bundle 或 unsigned debug HAP 成功只證明專案形態與建置路徑相容，不代表 runtime parity、簽名、實機或 release 驗收。
