### PR TITLE
🔧 chore(dependabot): configure version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    exclude-paths:
+      - "fixtures/**"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- configure weekly pnpm/npm dependency updates from the root workspace
- configure weekly GitHub Actions updates
- group minor and patch updates while keeping major updates separate
- exclude fixture manifests and cap concurrent update PRs

## Verification
- Dependabot YAML structure check passed
- `pnpm build`
- `pnpm test` (18 suites, 147 tests)
- `git diff --check`

Dependabot alerts remain enabled. Security updates remain disabled.

Rollback: remove `.github/dependabot.yml`.